### PR TITLE
check for the correct padding, INFO

### DIFF
--- a/WaveTools/DWTWaveStringChunk.m
+++ b/WaveTools/DWTWaveStringChunk.m
@@ -35,6 +35,13 @@
         mStringValue = [stringValue retain];
         NSMutableData* newData = [NSMutableData dataWithLength:0];
         [newData writeNulTerminatedString:mStringValue atOffset:0];
+        
+        // check for the correct padding
+        // An odd byte length chunks exists that is not immediately followed by a NULL byte.
+        // This could cause problems in reading subsequent chunks in some systems so add one more byte.
+        if (newData.length % 2 != 0) {
+            [newData writeNulTerminatedString:@"" atOffset:newData.length];
+        }
         self.directData = newData;
     }
 }


### PR DESCRIPTION
I'm not sure if you're still maintaining this framework, but it has been a big help to me. Wanted to submit this small fix. It was writing odd length INFO chunks which is against the wave spec and crashes some apps. Thanks! Ryan

An odd byte length chunks exists that is not immediately followed by a NULL byte.
This could cause problems in reading subsequent chunks in some systems so add one more byte.